### PR TITLE
Fix XML declaration in nodelet.launch

### DIFF
--- a/launch/nodelet.launch
+++ b/launch/nodelet.launch
@@ -1,4 +1,4 @@
-<? xml version="1.0" ?>
+<?xml version="1.0" ?>
 <launch>
 	<node pkg="nodelet" type="nodelet" name="standalone_nodelet"  args="manager" output="screen"/>
 


### PR DESCRIPTION
Without this, I am getting the following error on Kinetic:
```
Invalid roslaunch XML syntax: not well-formed (invalid token): line 1, column 2
The traceback for the exception was written to the log file
```

(and I am getting another error after this fix, but that's another story... `Failed to load nodelet [/CirclesCalibrationNodelet] of type [dr/CirclesCalibrationNodelet] even after refreshing the cache: According to the loaded plugin descriptions the class...`)