### PR TITLE
Fix crash when launching nodelets.

### DIFF
--- a/launch/nodelet.launch
+++ b/launch/nodelet.launch
@@ -2,7 +2,7 @@
 <launch>
 	<node pkg="nodelet" type="nodelet" name="standalone_nodelet"  args="manager" output="screen"/>
 
-	<node pkg="nodelet" type="nodelet" name="CirclesCalibrationNodelet" args="load dr/CirclesCalibrationNodelet standalone_nodelet" output="screen">
+	<node pkg="nodelet" type="nodelet" name="CameraPoseCalibrationNodelet" args="load camera_pose_calibration/CameraPoseCalibrationNodelet standalone_nodelet" output="screen">
 	</node>
 </launch>
 

--- a/nodelet_plugins.xml
+++ b/nodelet_plugins.xml
@@ -1,5 +1,5 @@
 <library path="lib/libcamera_pose_calibration_nodelet">
-	<class name="dr/CameraPoseCalibrationNodelet" type="dr::CirclesCalibrationNodelet" base_class_type="nodelet::Nodelet">
+	<class name="camera_pose_calibration/CameraPoseCalibrationNodelet" type="camera_pose_calibration::CameraPoseCalibrationNodelet" base_class_type="nodelet::Nodelet">
 		<description>Camera pose calibration using the OpenCV asymmetric circles pattern.</description>
 	</class>
 </library>


### PR DESCRIPTION
Launching this system crashes, probably due to some inconsistencies in the names of the nodelet plugins. This PR fixes that issue by making the names consistent.